### PR TITLE
linode private address subnet change

### DIFF
--- a/linode.yml
+++ b/linode.yml
@@ -3,10 +3,12 @@
 # Include your site.yml or just use the ceph-ansible sample:
 - include: "{{ lookup('env','CEPH_ANSIBLE') }}/site.yml.sample"
   vars:
-    cluster_network: 192.168.0.0/16
+    monitor_address_block: 192.168.128.0/17
+    public_network: 192.168.128.0/17
+    # there is no cluster network possible in linode at this time
+
     devices: [/dev/sdc]
     journal_collocation: true
     journal_size: 100
-    monitor_address_block: 192.168.0.0/16
-    pool_default_size: 2
-    public_network: 192.168.0.0/16
+    # if you want fewer than 3 OSD hosts in cluster...
+    #pool_default_size: 1


### PR DESCRIPTION
The linode.yml file had the wrong private IP subnet, at least for the linode nodes that I am using in New Jersey.  We don't need to set cluster_network since there is none.  Also, I thought we shouldn't set pool_default_size by default.  Finally I tried to group OSD parameters separately from other parameters.