### PR TITLE
avoid excessive -vvv logging, pretty-print JSON

### DIFF
--- a/ansible-env.bash
+++ b/ansible-env.bash
@@ -5,7 +5,7 @@ export ANSIBLE_SSH_RETRIES=20
 export ANSIBLE_STDOUT_CALLBACK=debug
 
 SSH_COMMON_ARGS="-o ConnectTimeout=60 -o ConnectionAttempts=10 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-ANSIBLE_ARGS="--timeout=60 -vv --forks=50 --become"
+ANSIBLE_ARGS="--timeout=60 -v --forks=50 --become"
 
 function repeat {
     while ! "$@"; do

--- a/ansible-env.bash
+++ b/ansible-env.bash
@@ -1,9 +1,11 @@
 export ANSIBLE_HOST_KEY_CHECKING=False
 export ANSIBLE_INVENTORY=ansible_inventory
 export ANSIBLE_SSH_RETRIES=20
+# pretty-print JSON to prevent logging hairballs
+export ANSIBLE_STDOUT_CALLBACK=debug
 
 SSH_COMMON_ARGS="-o ConnectTimeout=60 -o ConnectionAttempts=10 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-ANSIBLE_ARGS="--timeout=60 -vvv --forks=50 --become"
+ANSIBLE_ARGS="--timeout=60 -vv --forks=50 --become"
 
 function repeat {
     while ! "$@"; do


### PR DESCRIPTION
Make the logs from ceph-ansible a lot more readable, which is important, particularly at scale.  I never got anything useful from ansible by increasing logging to -vvv from -vv.  The logs generated by this are very long and uninformative.  The ANSIBLE_STDOUT_CALLBACK=debug change makes ansible output JSON strings in an indented form that is far more readable than the single-record JSON form that is the default.