### PR TITLE
Deploy from linode

### DIFF
--- a/linode-launch.py
+++ b/linode-launch.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import sys
+import socket
 
 from contextlib import closing, contextmanager
 from multiprocessing.dummy import Pool as ThreadPool
@@ -165,7 +166,12 @@ def launch(client):
             f.write("[{}]\n".format(group))
             for linode in linodes:
                 if linode['group'] == group:
-                    f.write("\t{} ansible_ssh_host={} ansible_ssh_port=22 ansible_ssh_user='root' ansible_ssh_private_key_file='{}'\n".format(linode['name'], linode['ip_private'], SSH_PRIVATE_KEY_FILE))
+                    if socket.gethostname().endswith('.linode.com'):
+                        # assumes deployment node is at same site as ceph cluster
+                        ip_key = 'ip_private'
+                    else:
+                        ip_key = 'ip_public'
+                    f.write("\t{} ansible_ssh_host={} ansible_ssh_port=22 ansible_ssh_user='root' ansible_ssh_private_key_file='{}'\n".format(linode['name'], linode[ip_key]
 
     with open("linodes", mode = 'w') as f:
         f.write(json.dumps(linodes))

--- a/linode-launch.py
+++ b/linode-launch.py
@@ -171,7 +171,7 @@ def launch(client):
                         ip_key = 'ip_private'
                     else:
                         ip_key = 'ip_public'
-                    f.write("\t{} ansible_ssh_host={} ansible_ssh_port=22 ansible_ssh_user='root' ansible_ssh_private_key_file='{}'\n".format(linode['name'], linode[ip_key]
+                    f.write("\t{} ansible_ssh_host={} ansible_ssh_port=22 ansible_ssh_user='root' ansible_ssh_private_key_file='{}'\n".format(linode['name'], linode[ip_key],  SSH_PRIVATE_KEY_FILE))
 
     with open("linodes", mode = 'w') as f:
         f.write(json.dumps(linodes))


### PR DESCRIPTION
This code tests to see if hostname ends with .linode.com, if it does then the private IP address is added to the ansible inventory file, otherwise the public IP address is added.  This allows the script to work either from an linode or a host external to linode.com.  If run from an linode, it must be at same geographical site as the ceph cluster.  I noticed that you changed code to use private IP addresses, and if everyone is running this deployment script from an linode, then you probably don't need it.