### PR TITLE
only try ceph-ansible 2 times

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -35,7 +35,7 @@ function main {
     if ! do_playbook --limit=all "$YML"; then
         # Always include the mons because we need their statistics to generate ceph.conf
         printf 'mons\nmgrs\n' >> "$RETRY"
-        repeat do_playbook --limit=@"${RETRY}" "$YML"
+        do_playbook --limit=@"${RETRY}" "$YML"
         rm -f -- "${RETRY}"
     fi
 }


### PR DESCRIPTION
If ceph-ansible doesn't work (e.g. because of a bad config parameter), launch.sh keeps retrying it and this means you're never really sure if the deploy failed because it just keeps running.  I get that you did this to work around first-time transient errors, but 2 times should be enough, right?