### PR TITLE
remove ansible_inventory so next launch.sh succeeds

### DIFF
--- a/linode-destroy.py
+++ b/linode-destroy.py
@@ -35,5 +35,18 @@ def main():
     linodes = client.linode_list()
     logging.info("linodes: {}".format(linodes))
 
+    # clear inventory file or else launch.sh won't create linodes
+    
+    ansible_inv_file = os.getenv('ANSIBLE_INVENTORY')
+    if not ansible_inv_file:
+        ansible_inv_file = 'ansible_inventory'
+    try:
+      os.unlink(ansible_inv_file)
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise e
+    
+    logging.info('removed ansible inventory file %s' % ansible_inv_file)
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
remove ansible inventory file when destroying nodes.   Otherwise launch.sh won't create new linodes.  There is no point in retaining the old inventory file because the IP addresses in there are no longer valid.  I just tested this, and you can now run linode-destroy.py and then immediately run launch.sh and it will work. 