### PR TITLE
Update cluster.json.sample for new plan labels

### DIFF
--- a/cluster.json.sample
+++ b/cluster.json.sample
@@ -2,32 +2,32 @@
   {
     "count": 3,
     "prefix": "mon",
-    "plan": 1024,
+    "plan": 1,
     "group": "mons"
   },
   {
     "count": 3,
     "prefix": "osd",
-    "plan": 1024,
+    "plan": 1,
     "root_size": 4096,
     "group": "osds"
   },
   {
     "count": 1,
     "prefix": "mds",
-    "plan": 1024,
+    "plan": 1,
     "group": "mdss"
   },
   {
     "count": 1,
     "prefix": "mgr",
-    "plan": 1024,
+    "plan": 1,
     "group": "mgrs"
   },
   {
     "count": 1,
     "prefix": "client",
-    "plan": 1024,
+    "plan": 1,
     "group": "clients"
   }
 ]


### PR DESCRIPTION
Linode plan labels have changed slightly. Instead of "Linode 1024",
"Linode 2048", etc., plan labels are now in the form of "Nanode 1GB",
"Linode 2GB", "Linode 4GB", and so on.

Updated the sample cluster.json to reflect this. A simple number (in
gigabytes) for the plan will work.