### PR TITLE
allow user to create VMs without running ceph-ansible

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -31,8 +31,11 @@ function main {
         ans --module-name=shell --args='wipefs -a /dev/sdc' osds
     fi
 
+    if [ ! -d $CEPH_ANSIBLE/roles ] ; then
+        echo "skipping ceph-ansible run"
+
     # Sometimes we hit transient errors, so retry until it works!
-    if ! do_playbook --limit=all "$YML"; then
+    elif ! do_playbook --limit=all "$YML"; then
         # Always include the mons because we need their statistics to generate ceph.conf
         printf 'mons\nmgrs\n' >> "$RETRY"
         do_playbook --limit=@"${RETRY}" "$YML"
@@ -86,7 +89,6 @@ set -x
 
 if ! [ -d "$CEPH_ANSIBLE"/roles ]; then
     printf "Cannot find ceph-ansible environment, please specify the path to ceph-ansible. (current: %s)\n" "$CEPH_ANSIBLE"
-    exit 1
 fi
 
 cat > ansible.cfg <<EOF


### PR DESCRIPTION
by specifying a non-existent ceph-ansible directory
or not specifying it at all.
Lets user provide extra packages before running ceph-ansible.
Since linode-launch.py will not re-create existing VMs,
and since pre-config.yml is idempotent and doesn't take long,
you can just rerun launch.sh with the correct
ceph-ansible directory after extra packages are provided