### PR TITLE
Add workload for testing horizontal scaling of metadata

### DIFF
--- a/misc/horizontal-scale-mkdir.sh
+++ b/misc/horizontal-scale-mkdir.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e
+
+ephemeral_distributed="$1"
+rm_dir="$2"
+
+N="$3"
+if [ -z "$N" ]; then
+    N=1 
+fi
+
+
+function do_scale_test {
+    TESTDIR="/cephfs/"
+    mkdir -p "$TESTDIR"
+    T=$(mktemp -d -p "$TESTDIR")
+    cd "$T"
+    # Avoiding directory fragmentation for now, hence creating a new parent directory
+    # after every 9998 child directories
+    for ((i = 0; i < 100; ++i)); do
+      mkdir "$i"
+      if [ "$ephemeral_distributed" == "--ephemeral-distributed" ]; then
+          setfattr -n ceph.dir.distributed.pin -v 1 $i
+      fi
+      for ((j = 0; j < 9998; ++j)); do
+        mkdir "$i/$j"
+      done
+    done
+    if [ "$rm_dir" == "--remove-dir" ]; then
+      rm -rfv "$T"
+    fi
+}
+
+{
+    count=0
+    while true; do
+        if systemctl status ceph-fuse@-cephfs || [ "$(stat -f --format=%t /cephfs)" = c36400 ]; then
+            break # shell ! is stupid, can't move to while
+        fi
+        sleep 5
+        if ((++count > 60)); then
+            exit 1
+        fi
+    done
+
+    for ((i = 0; i < N; ++i)); do
+        do_scale_test &> /root/client-output-$i.txt &
+    done
+    wait
+} > /root/client-output.txt 2>&1

--- a/scripts/cephfs-horizontal-scale-mkdir.sh
+++ b/scripts/cephfs-horizontal-scale-mkdir.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+###
+
+# Use option --ephemeral-distributed to enable ephemeral distributed pinning on the parent directories
+# Use option --remove-dir to remove the directories after they are created
+
+set -e
+
+ephemeral_distributed=$1
+remove_dir=$2
+
+MAX_MDS=$(< linodes jq --raw-output 'map(select(.name | startswith("mds"))) | length')
+MAX_MDS=$((MAX_MDS-1)) # leave one for standby
+NUM_CLIENTS=$(< linodes jq --raw-output 'map(select(.name | startswith("client"))) | length')
+
+TEST=kernel
+
+###
+
+# may be necessary for ansible with >25 forks
+ulimit -n 65536 || true
+
+LOG=$(date +OUTPUT-%Y%m%d-%H:%M)
+EXPERIMENT=$(date +experiment-%Y%m%d-%H:%M)
+RESULTS=/results/
+
+source ansible-env.bash
+
+function run {
+  printf '%s\n' "$*"
+  "$@"
+}
+
+function ssh {
+  /usr/bin/ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PreferredAuthentications=publickey "$@"
+}
+
+function scp {
+  /usr/bin/scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PreferredAuthentications=publickey "$@"
+}
+
+function nclients {
+  n="$1"
+  for ((i = 1; i <= n; i++)); do
+    if [[ $i > 1 ]]; then
+      printf ' '
+    fi
+    printf "client-%03d" "$((i-1))"
+  done
+}
+
+function do_test {
+  run ans -m shell -a "/root/horizontal_scale_mkdir.sh $ephemeral_distributed $remove_dir" "$1"
+}
+
+function do_tests {
+  exp="$1"
+  i="$2"
+  max_mds="$3"
+  num_clients="$4"
+  for size in 1GB 2GB; do
+    instance="$(printf 'max_mds:%02d/num_clients:%02d/i:%02d/%s' "$max_mds" "$num_clients" "$i" "$size")"
+    dir="${exp}/results/${instance}"
+    run mkdir -p "$dir/${TEST}"
+    printf '%d\n' "$i" > "$dir"/i
+    printf '%d\n' "$max_mds" > "$dir"/max_mds
+    printf '%d\n' "$num_clients" > "$dir"/num_clients
+    printf '%s\n' "$instance" > "$dir"/instance
+    printf '%s\n' "$(date +%Y%m%d-%H:%M)" > "$dir"/date
+    run do_playbook playbooks/cephfs-pre-test.yml
+
+    run ans -m shell -a "ceph config set mds mds_cache_memory_limit $size" mon-000
+
+    run ans -m shell -a 'df -h /cephfs/' clients &> "$dir/${TEST}/pre-df"
+    date +%s > "$dir/${TEST}/start"
+    run do_test "$(nclients "$num_clients")" |& tee "$dir/${TEST}/log"
+    date +%s > "$dir/${TEST}/end"
+    run ans -m shell -a 'df -h /cephfs/' clients &> "$dir/${TEST}/post-df"
+
+    run do_playbook --extra-vars instance="$dir" playbooks/cephfs-post-test.yml
+  done
+}
+
+function main {
+  exp="${RESULTS}/${EXPERIMENT}"
+  mkdir -p -- "$exp"
+
+  run cp -av -- launch.log ansible_inventory linodes cluster.json group_vars "$exp/"
+
+  {
+    run do_playbook playbooks/cephfs-setup.yml
+    run ans --module-name=copy --args="src=misc/horizontal_scale_mkdir.sh dest=/root/ owner=root group=root mode=755" clients
+    for ((max_mds = 1; max_mds <= MAX_MDS; ++max_mds)); do
+      for ((num_clients = 1; num_clients <= NUM_CLIENTS; num_clients*=2)); do
+        if [[ $max_mds == 1 && $num_clients > 4 ]]; then
+          break
+        fi
+        for ((i = 0; i < 2; i++)); do
+          run do_playbook playbooks/cephfs-reset.yml
+          ans -m shell -a "ceph fs set cephfs max_mds $max_mds" mon-000
+          run do_tests "$exp" "$i" "$max_mds" "$num_clients" || true
+        done
+      done
+    done
+  } |& tee "${exp}/experiment.log"
+}
+
+ARGUMENTS='--options e:,h,l:,r: --long experiment:,help,results:'
+NEW_ARGUMENTS=$(getopt $ARGUMENTS -- "$@")
+eval set -- "$NEW_ARGUMENTS"
+
+function usage {
+    printf "%s: [--experiment <experiment>]\n" "$0"
+}
+
+while [ "$#" -ge 0 ]; do
+    case "$1" in
+        -e|--experiment)
+            shift
+            EXPERIMENT="$1"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit
+            ;;
+        --metadata-pg)
+            shift
+            METADATA_PG="$1"
+            shift
+            ;;
+        --data-pg)
+            shift
+            DATA_PG="$1"
+            shift
+            ;;
+        -r|--results)
+            shift
+            RESULTS="$1"
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+    esac
+done
+
+main "$@"


### PR DESCRIPTION
Each client applies the workload on its own private directory. Multiple directories are created under a common directory. A new common directory is created when the no of child directories exceed 9998 to prevent the effects of directory fragmentation (for now).

Committer: Sidharth Anupkrishnan <sanupkri@redhat.com>