### PR TITLE
use centos-stream8 image instead of centos8 image

### DIFF
--- a/cluster.json.sample
+++ b/cluster.json.sample
@@ -1,6 +1,6 @@
 {
   "region": "us-west",
-  "image": "CentOS 8",
+  "image": "linode/centos-stream8",
   "type": 8192,
   "nodes": [
       {

--- a/linode.py
+++ b/linode.py
@@ -215,7 +215,7 @@ class CephLinode():
         elif self.cluster.get('image'):
             i = self.cluster['image']
         else:
-            i = "linode/centos8"
+            i = "linode/centos-stream8"
 
         best = None
         for image in self._images:


### PR DESCRIPTION
... since CentOS 8 has gone EOL (Dec 31 2021).

Signed-off-by: Ramana Raja <rraja@redhat.com>